### PR TITLE
fixed a bug where Prefs.extensions would be None after sublime restarted

### DIFF
--- a/tagify.py
+++ b/tagify.py
@@ -152,7 +152,7 @@ class TagifyCommand(sublime_plugin.WindowCommand):
             for dirname, dirnames, filenames in os.walk(folder):
                 for filename in filenames:
                     ext = filename.split('.')[-1]
-                    processed_extensions = Prefs.extensions
+                    processed_extensions = settings.get('extensions', ["py", "html", "htm", "js"])
                     if ext in processed_extensions:
                         self.tagify_file(dirname, filename, ctags, folder)
         TagifyCommon.taglist = list(ctags.keys())


### PR DESCRIPTION
This caused an error in the console and prevented the tag list from opening. There seems to be a similar problem with ShowTagsMenuCommand, but with this change at least the tag list works
